### PR TITLE
fix: support CJK input in chat text field

### DIFF
--- a/aizen/Views/Chat/Components/ChatInputView.swift
+++ b/aizen/Views/Chat/Components/ChatInputView.swift
@@ -66,7 +66,8 @@ struct CustomTextEditor: NSViewRepresentable {
         guard let textView = nsView.documentView as? NSTextView else { return }
         context.coordinator.scrollView = nsView
 
-        if textView.string != text {
+        // Skip text updates during IME composition to avoid breaking CJK input
+        if textView.string != text && !textView.hasMarkedText() {
             textView.string = text
 
             // Apply mention highlighting
@@ -208,6 +209,8 @@ struct CustomTextEditor: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            // Skip updates during IME composition (marked text) to avoid breaking CJK input
+            guard !textView.hasMarkedText() else { return }
             text = textView.string
             highlightMentions(in: textView)
             notifyCursorChange(textView)


### PR DESCRIPTION
## Summary

- Fix chat input field not accepting Chinese (and other CJK languages) input
- Skip text synchronization during IME composition to prevent interrupting input method state

## Problem

When using Chinese input method, the input field gets interrupted during pinyin composition, making it impossible to type Chinese characters normally.

## Root Cause

The `CustomTextEditor`'s `textDidChange` and `updateNSView` methods synchronize text and modify textStorage even when the input method has marked text (pre-edit text), which interrupts the IME composition state.

## Solution

Add `hasMarkedText()` checks at two critical locations:
1. `textDidChange` - Return early when marked text exists, skip updating text binding
2. `updateNSView` - Skip overwriting textView.string when marked text exists

## Test Plan

- [ ] Switch to Chinese input method, type pinyin in chat input and select characters
- [ ] Verify Japanese and Korean input methods work correctly
- [ ] Confirm English input and @mention highlighting still work as expected