### PR TITLE
fix: copy shell integration files directly from source directory

### DIFF
--- a/scripts/organize-resources.sh
+++ b/scripts/organize-resources.sh
@@ -48,23 +48,47 @@ fi
 mkdir -p "${RESOURCES_DIR}/ghostty/themes"
 mkdir -p "${RESOURCES_DIR}/ghostty/shell-integration"/{bash,elvish,fish,zsh}
 
-# Move shell integration files with explicit error handling
-declare -A SHELL_FILES=(
-    ["ghostty.bash"]="bash/ghostty.bash"
-    ["bash-preexec.sh"]="bash/bash-preexec.sh"
-    ["ghostty-integration.elv"]="elvish/ghostty-integration.elv"
-    ["ghostty-shell-integration.fish"]="fish/ghostty-shell-integration.fish"
-    ["ghostty-integration"]="zsh/ghostty-integration"
-    [".zshenv"]="zsh/.zshenv"
-)
+# Copy shell integration files from source directory
+# These files are not in Xcode's Copy Bundle Resources, so we copy them directly
+SHELL_INTEGRATION_SRC="${SRCROOT}/aizen/Resources/ghostty/shell-integration"
 
-for src in "${!SHELL_FILES[@]}"; do
-    if [ -f "${RESOURCES_DIR}/${src}" ]; then
-        mv "${RESOURCES_DIR}/${src}" "${RESOURCES_DIR}/ghostty/shell-integration/${SHELL_FILES[$src]}" || {
-            echo "Warning: Failed to move ${src}" >&2
+if [ -d "${SHELL_INTEGRATION_SRC}" ]; then
+    # Copy zsh integration (including hidden .zshenv)
+    if [ -d "${SHELL_INTEGRATION_SRC}/zsh" ]; then
+        cp -a "${SHELL_INTEGRATION_SRC}/zsh/." "${RESOURCES_DIR}/ghostty/shell-integration/zsh/" || {
+            echo "Warning: Failed to copy zsh shell integration" >&2
         }
     fi
-done
+
+    # Copy other shell integrations if they exist
+    for shell in bash elvish fish; do
+        if [ -d "${SHELL_INTEGRATION_SRC}/${shell}" ]; then
+            cp -a "${SHELL_INTEGRATION_SRC}/${shell}/." "${RESOURCES_DIR}/ghostty/shell-integration/${shell}/" || {
+                echo "Warning: Failed to copy ${shell} shell integration" >&2
+            }
+        fi
+    done
+
+    echo "Shell integration files copied from source"
+else
+    # Fallback: try to move from flattened Resources (legacy behavior)
+    declare -A SHELL_FILES=(
+        ["ghostty.bash"]="bash/ghostty.bash"
+        ["bash-preexec.sh"]="bash/bash-preexec.sh"
+        ["ghostty-integration.elv"]="elvish/ghostty-integration.elv"
+        ["ghostty-shell-integration.fish"]="fish/ghostty-shell-integration.fish"
+        ["ghostty-integration"]="zsh/ghostty-integration"
+        [".zshenv"]="zsh/.zshenv"
+    )
+
+    for src in "${!SHELL_FILES[@]}"; do
+        if [ -f "${RESOURCES_DIR}/${src}" ]; then
+            mv "${RESOURCES_DIR}/${src}" "${RESOURCES_DIR}/ghostty/shell-integration/${SHELL_FILES[$src]}" || {
+                echo "Warning: Failed to move ${src}" >&2
+            }
+        fi
+    done
+fi
 
 # Move theme files (files without extensions, not directories, excluding known patterns)
 # Only process potential theme files to avoid iterating over all resources


### PR DESCRIPTION
## Problem

User's `~/.zshrc` was not being loaded in the terminal. The `ZDOTDIR` environment variable remained set to the shell-integration directory instead of being unset, preventing zsh from loading user configuration files from `$HOME`.

## Root Cause

The shell integration files (`.zshenv`, `ghostty-integration`) were not being copied to the app bundle.

The `organize-resources.sh` script expected Xcode to first copy these files to the Resources directory via "Copy Bundle Resources", then the script would reorganize them into the correct directory structure. However, these files were never added to the Xcode project, so they were never copied.

As a result, when libghostty set `ZDOTDIR` to point to the shell-integration directory:
1. zsh looked for `$ZDOTDIR/.zshenv` but the file was missing
2. The shell integration script never executed
3. `ZDOTDIR` was never unset
4. zsh didn't load `~/.zshrc` from `$HOME`

## Solution

Modified `organize-resources.sh` to copy shell integration files directly from the source directory (`${SRCROOT}/aizen/Resources/ghostty/shell-integration`) instead of relying on Xcode's "Copy Bundle Resources" phase.

The fallback logic is preserved for backward compatibility.

## Testing

1. Clean build the project
2. Verify files exist in app bundle:
   ```bash
   ls -la "...aizen.app/Contents/Resources/ghostty/shell-integration/zsh/"
   ```
3. Open a new terminal in the app
4. Verify `~/.zshrc` is loaded (check PATH, prompt theme, etc.)